### PR TITLE
Make name parsing spec compliant

### DIFF
--- a/Sources/SwiftGraphQl/Lexer.swift
+++ b/Sources/SwiftGraphQl/Lexer.swift
@@ -150,8 +150,10 @@ struct GraphQlLexer {
   static let assignment = "=" ^^ { _ in StreamToken.assignment }
   static let exclamation = "!" ^^ { _ in StreamToken.exclamation }
 
-  static let nameStart = match(CharacterSet.alphanumerics)
-  static let nameCharacter = nameStart | match(element: Character("_"))
+  static let lowerAlpha = match(CharacterSet(charactersIn: "a"..."z"))
+  static let upperAlpha = match(CharacterSet(charactersIn: "A"..."Z"))
+  static let nameStart = match(element: Character("_")) | upperAlpha | lowerAlpha
+  static let nameCharacter = nameStart | match(CharacterSet(charactersIn: "0"..."9"))
   static let name = nameStart ~ nameCharacter* ^^ { StreamToken.name(String($0) + String($1)) }
   static let variable = "$" <~ nameCharacter+ ^^ { StreamToken.variable(String($0)) }
   static let directive = "@" <~ nameCharacter+ ^^ { StreamToken.directive(String($0)) }

--- a/Tests/SwiftGraphQlTests/LexerTests.swift
+++ b/Tests/SwiftGraphQlTests/LexerTests.swift
@@ -86,7 +86,7 @@ Always sings aloud!\"\"\"
       ("testFloatLiteral", testFloatLiteral),
       ("testEscapedCharacter", testEscapedCharacter),
       ("testUnicodeCharacter", testUnicodeCharacter),
-      ("testLineTerminator", testEscapedCharacter),
+      ("testLineTerminator", testLineTerminator),
       ("testStringCharacter", testStringCharacter),
       ("testDoubleQuotedStringValue", testDoubleQuotedStringValue),
       ("testBlockStringCharacter", testBlockStringCharacter),

--- a/Tests/SwiftGraphQlTests/LexerTests.swift
+++ b/Tests/SwiftGraphQlTests/LexerTests.swift
@@ -56,8 +56,22 @@ Always sings aloud!\"\"\"
     
     assertParsed(GraphQlLexer.stringValue, input: input, val: StreamToken.stringValue("How sweet to be a Cloud\nFloating in the \"Blue!\"\nEvery \\little\\ cloud\nAlways sings aloud!"))
   }
-  
-  func testNameKeywordDisambiuation() {
+
+  func testNameValue() {
+    let lexer = GraphQlLexer.name
+
+    assertParsed(lexer, input: "field", val: StreamToken.name("field"))
+    assertParsed(lexer, input: "Field", val: StreamToken.name("Field"))
+    assertParsed(lexer, input: "_field", val: StreamToken.name("_field"))
+    assertParsed(lexer, input: "__typename", val: StreamToken.name("__typename"))
+    assertParsed(lexer, input: "a1", val: StreamToken.name("a1"))
+    assertParsed(lexer, input: "e", val: StreamToken.name("e"))
+
+    assertNotParsed(lexer, input: "é")
+    assertNotParsed(lexer, input: "1")
+  }
+
+  func testNameKeywordDisambiguation() {
     let lexer = GraphQlLexer.keywords | GraphQlLexer.name
     
     assertParsed(lexer, input: "query_field", val: StreamToken.name("query_field"))
@@ -71,9 +85,13 @@ Always sings aloud!\"\"\"
       ("testIntLiteral", testIntLiteral),
       ("testFloatLiteral", testFloatLiteral),
       ("testEscapedCharacter", testEscapedCharacter),
-      ("testEscapedCharacter", testEscapedCharacter),
       ("testUnicodeCharacter", testUnicodeCharacter),
+      ("testLineTerminator", testEscapedCharacter),
+      ("testStringCharacter", testStringCharacter),
       ("testDoubleQuotedStringValue", testDoubleQuotedStringValue),
-      ("testBlockQuotedStringValue", testBlockQuotedStringValue)
+      ("testBlockStringCharacter", testBlockStringCharacter),
+      ("testBlockQuotedStringValue", testBlockQuotedStringValue),
+      ("testNameValue", testNameValue),
+      ("testNameKeywordDisambiguation", testNameKeywordDisambiguation)
   ]
 }


### PR DESCRIPTION
This fixes a specific issue where a selection including `__typename` would fail parsing, and makes the name parsing [spec compliant](http://spec.graphql.org/June2018/#sec-Names)