### PR TITLE
Reject invalid TypeCondition expressions

### DIFF
--- a/Sources/SwiftGraphQl/Parser.swift
+++ b/Sources/SwiftGraphQl/Parser.swift
@@ -121,7 +121,7 @@ struct GraphQlDocumentParser {
   static let fragmentSpread = match(StreamToken.ellipsis) <~ name ~ directives ^^ { (name, directives) in
     Selection.fragmentSpread(name, directives)
   }
-  static let typeCondition = match(StreamToken.on) <~ type
+  static let typeCondition = match(StreamToken.on) <~ namedType
   // inlineFragment must come before fragmentSpread because "... on" is more specific than "... Foo"
   static let selection = fieldAsSelection | inlineFragment() | fragmentSpread
   static let selectionSet: () -> StreamTokenParser<[Selection]> = { match(StreamToken.leftCurly) <~ selection+ ~> match(StreamToken.rightCurly) }

--- a/Tests/SwiftGraphQlTests/ParserTests.swift
+++ b/Tests/SwiftGraphQlTests/ParserTests.swift
@@ -239,6 +239,22 @@ final class ParserTests: XCTestCase, ParserHelpers {
                   StreamToken.exclamation],
                  val: Type.required(Type.named("Test")))
   }
+  func testTypeCondition() {
+    // on Test
+    assertParsed(GraphQlDocumentParser.typeCondition,
+                 input: [
+                  StreamToken.on,
+                  StreamToken.name("Test")],
+                 val: Type.named("Test"))
+
+    // on [Test]
+    assertNotParsed(GraphQlDocumentParser.typeCondition,
+                    input: [
+                     StreamToken.on,
+                     StreamToken.leftBracket,
+                     StreamToken.name("Test"),
+                     StreamToken.rightBracket])
+  }
   func testVariable() {
     // $var
     assertParsed(GraphQlDocumentParser.variable,


### PR DESCRIPTION
According to the [spec](http://spec.graphql.org/June2018/#TypeCondition), we should only parse named types, not all types


    TypeCondition:
      on NamedType
